### PR TITLE
BRStringPickerView 优化一处逻辑

### DIFF
--- a/BRPickerView/StringPickerView/BRStringPickerView.m
+++ b/BRPickerView/StringPickerView/BRStringPickerView.m
@@ -162,7 +162,8 @@ typedef NS_ENUM(NSInteger, BRStringPickerMode) {
             // 默认滚动的行
             [self.pickerView selectRow:row inComponent:i animated:NO];
         }
-        self.selectValueArr = [tempArr copy];
+//        self.selectValueArr = [tempArr copy];
+        self.selectValueArr = tempArr; //
     }
 }
 
@@ -237,15 +238,17 @@ typedef NS_ENUM(NSInteger, BRStringPickerMode) {
             break;
         case BRStringPickerComponentMore:
         {
-            NSMutableArray *tempArr = [NSMutableArray array];
-            for (NSInteger i = 0; i < self.selectValueArr.count; i++) {
-                if (i == component) {
-                    [tempArr addObject:self.dataSourceArr[component][row]];
-                } else {
-                    [tempArr addObject:self.selectValueArr[i]];
-                }
-            }
-            self.selectValueArr = tempArr;
+//            NSMutableArray *tempArr = [NSMutableArray array];
+//            for (NSInteger i = 0; i < self.selectValueArr.count; i++) {
+//                if (i == component) {
+//                    [tempArr addObject:self.dataSourceArr[component][row]];
+//                } else {
+//                    [tempArr addObject:self.selectValueArr[i]];
+//                }
+//            }
+//            self.selectValueArr = tempArr;
+
+            self.selectValueArr[component] = self.dataSourceArr[component][row];//直接修改
             
             // 设置是否自动回调
             if (self.isAutoSelect) {


### PR DESCRIPTION
1.直接修改selectValueArr对应的component位置的值就行了,感觉没有必要创建一个新的容器。
2. didSelectRow 这个方法调用的频率非常高，每次都创建新数组，有点浪费，相对来说也会导致内存增加
3.个人建议： self.selectValueArr[component] = self.dataSourceArr[component][row];//直接修改
4.selectValueArr 是一个可数组，不需要copy.



